### PR TITLE
Enhancements

### DIFF
--- a/src/test/groovy/com/rundeck/plugins/logging/JsonLogFilterSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/logging/JsonLogFilterSpec.groovy
@@ -59,6 +59,7 @@ class JsonLogFilterSpec extends Specification {
                 'test'  : 'value',
                 'something2' : 'value1'
         ]
+        false | ".id"           | ['{"id":"abc12345"}']                         | [result: 'abc12345']
     }
 
     def "array test"() {


### PR DESCRIPTION
JQ filter string now supports context replacements.
Output of string types no longer puts double quotes around the emitted value. This is simalar to using jq with the -r switch.