### PR TITLE
RUN-3601: CVE-2025-48924 Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
     implementation 'org.codehaus.groovy:groovy-all:3.0.19'
 
     implementation group: 'org.rundeck', name: 'rundeck-core', version: rundeckVersion
+    
+    // Add secure commons-lang3 to provide alternative to vulnerable commons-lang 2.6
+    implementation 'org.apache.commons:commons-lang3:3.18.0'
 
     pluginLibs (group: 'net.thisptr', name: 'jackson-jq', version: '1.0.0-preview.20230409') {
        exclude group: "com.fasterxml.jackson.core"
@@ -73,6 +76,15 @@ dependencies {
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation "org.spockframework:spock-core:2.0-groovy-3.0"
+}
+
+configurations.all {
+    resolutionStrategy {
+        // Replace vulnerable commons-lang with secure commons-lang3
+        dependencySubstitution {
+            substitute module('commons-lang:commons-lang') using module('org.apache.commons:commons-lang3:3.18.0')
+        }
+    }
 }
 
 


### PR DESCRIPTION
Mitigates CVE-2025-48924 by upgrading commons-lang to commons-lang3 3.18.0.

**Changes:**
- Added commons-lang3 3.18.0 dependency to build.gradle
- Configured dependency substitution to replace vulnerable commons-lang with secure commons-lang3
- Ensures all transitive dependencies use the secure version

**Security Impact:**
This change addresses the security vulnerability identified in CVE-2025-48924 by replacing the vulnerable commons-lang 2.x library with the secure commons-lang3 3.18.0 version.