### PR TITLE
[RUN-4161] add default value to extraQuotes to avoid null

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/logging/JsonLogFilter.groovy
+++ b/src/main/groovy/com/rundeck/plugins/logging/JsonLogFilter.groovy
@@ -47,10 +47,10 @@ See [here](https://github.com/eiiches/jackson-jq#implementation-status-and-curre
     )
     Boolean logData
 
-    //Note: we don't set a defaultValue, so that we can detect a null value if the user has not set it
     @PluginProperty(
             title = 'Extra quotes (Rundeck 4.x Compatibility)',
-            description = '''If true, the result will be parsed to a string with extra quotes to match Rundeck 4.x behavior.'''
+            description = '''If true, the result will be parsed to a string with extra quotes to match Rundeck 4.x behavior.''',
+            defaultValue = 'false'
     )
     Boolean extraQuotes
 
@@ -82,14 +82,7 @@ See [here](https://github.com/eiiches/jackson-jq#implementation-status-and-curre
     void complete(final PluginLoggingContext context) {
 
         if(buffer.size()>0) {
-            if (extraQuotes == null) {
-                //fall back to previous behavior
-                extraQuotes = true
-                context.log(
-                        1,
-                        'JSON jq key/value mapper: defaulting to rundeck 4.x quoting behavior'
-                )
-            }else if(extraQuotes){
+            if(extraQuotes){
                 context.log(
                         1,
                         'JSON jq key/value mapper: Using rundeck 4.x quoting behavior'

--- a/src/test/groovy/com/rundeck/plugins/logging/JsonLogFilterSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/logging/JsonLogFilterSpec.groovy
@@ -104,10 +104,10 @@ class JsonLogFilterSpec extends Specification {
 
         quoteVal | dolog | filter | lines                | expect
         false    | true  | "."    | ['{"test":"value"}'] | [test: 'value']
-        null     | true  | "."    | ['{"test":"value"}'] | [test: '"value"']
+        null     | true  | "."    | ['{"test":"value"}'] | [test: 'value']
         true     | true  | "."    | ['{"test":"value"}'] | [test: '"value"']
         true     | true  | "."    | ['["value"]']        | ['result.0': '"value"']
-        null     | true  | "."    | ['["value"]']        | ['result.0': '"value"']
+        null     | true  | "."    | ['["value"]']        | ['result.0': 'value']
         false    | true  | "."    | ['["value"]']        | ['result.0': 'value']
 
     }


### PR DESCRIPTION
This pull request updates the default behavior of the `extraQuotes` property in the `JsonLogFilter` plugin to improve compatibility and simplify configuration. The most important changes are summarized below:

### Plugin property defaults and behavior

* Set a default value of `false` for the `extraQuotes` property in the `JsonLogFilter` plugin, so users no longer need to specify it unless they want Rundeck 4.x compatibility.
* Removed the fallback logic that defaulted `extraQuotes` to `true` when not explicitly set, aligning the plugin's behavior with the new default.

### Test updates

* Updated tests in `JsonLogFilterSpec.groovy` to reflect the new default behavior for `extraQuotes`, ensuring that when it is `null`, the output matches the non-quoted (default) behavior.